### PR TITLE
Add doc workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,11 @@
+name: Documentation
+
+on: [push, pull_request]
+
+jobs:
+  Documentation:
+    permissions:
+      # needs write permission to push the docs to gh-pages
+      contents: write
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/doc.yml@main

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,9 +3,15 @@ name: Documentation
 on: [push, pull_request]
 
 jobs:
-  Documentation:
+  Build:
+    # Use the "reusable workflow" from the hyperspy organisation
+    uses: hyperspy/.github/.github/workflows/doc.yml@main
+
+  Push:
+    needs: Build
+    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'hyperspy' }}
     permissions:
       # needs write permission to push the docs to gh-pages
       contents: write
     # Use the "reusable workflow" from the hyperspy organisation
-    uses: hyperspy/.github/.github/workflows/doc.yml@main
+    uses: hyperspy/.github/.github/workflows/push_doc.yml@main

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ https://holospy.readthedocs.io/en/latest/changes.html
 - Rename the ``max_workers`` argument to ``num_workers`` (`#9 <https://github.com/hyperspy/holospy/pull/9>`_)
 - Setup codecov to measure coverage (`#10 <https://github.com/hyperspy/holospy/pull/10>`_)
 - Add badges for tests, codecov and docs (`#11 <https://github.com/hyperspy/holospy/pull/11>`_)
+- Add workflow to build and push documentation (`#13 <https://github.com/hyperspy/holospy/pull/13>`_)
 
 Initiation (2023-07-23)
 =======================

--- a/doc/api/data.rst
+++ b/doc/api/data.rst
@@ -1,0 +1,5 @@
+:mod:`holospy.data`
+-------------------
+
+.. automodule:: holospy.data
+   :members:

--- a/doc/api/datasets.rst
+++ b/doc/api/datasets.rst
@@ -1,5 +1,0 @@
-:mod:`holospy.datasets`
------------------------
-
-.. automodule:: holospy.datasets
-   :members:

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -8,7 +8,7 @@ Reference
    :caption: API Reference
    :maxdepth: 2
 
-   datasets
+   data
    reconstruct
    signals
    tools

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -6,7 +6,7 @@ HoloSpy is maintained by the HyperSpy community
 
 If HoloSpy has been significant to a project that leads to an academic
 publication, please acknowledge that fact by citing it. The DOI in the
-badge below is the `Concept DOI <https://help.zenodo.org/fag/#versioning>`_ --
+badge below is the `Concept DOI <https://help.zenodo.org/faq/#versioning>`_ --
 it can be used to cite the project without referring to a specific
 version. If you are citing HoloSpy because you have used it to process data,
 please use the DOI of the specific version that you have employed. You can

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,6 +40,10 @@ extensions = [
     "sphinx.ext.napoleon",
 ]
 
+linkcheck_ignore = [
+    "https://onlinelibrary.wiley.com",  # 403 Client Error: Forbidden for url
+]
+
 intersphinx_mapping = {
     "dask": ("https://docs.dask.org/en/latest", None),
     "hyperspy": ("https://hyperspy.org/hyperspy-doc/current/", None),

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -80,7 +80,7 @@ entered into an anaconda prompt (from scratch):
 Installation using pip
 ========================
 
-Alternatively, you can also find HoloSpy in the `Python Package Index (PyPI) <pypi.org>`_
+Alternatively, you can also find HoloSpy in the `Python Package Index (PyPI) <https://pypi.org>`_
 and install it using (requires ``pip``):
 
 .. code-block:: bash


### PR DESCRIPTION
Documentation for reusable workflow: https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow

### Progress of the PR
- [x] Add doc workflow using reusable workflow from hyperspy organisation (https://github.com/hyperspy/.github/blob/main/workflows/doc.yml),
- [x] fix external links 
- [n/a] docstring updated (if appropriate),
- [x] update user guide (if appropriate),
- [n/a] added tests,
- [x] added line to CHANGES.rst,


