### PR TITLE
Release 0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,8 @@
 name: Release
+# Reusable workflow are not supported with trusted publisher
+# https://github.com/pypa/gh-action-pypi-publish/issues/166
+# copy and paste
+# https://github.com/hyperspy/.github/blob/main/.github/workflows/release_pure_python.yml
 
 # This workflow builds the wheels "on tag".
 # If run from the hyperspy/hyperspy repository, the wheels will be uploaded to pypi ;
@@ -10,14 +14,60 @@ on:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  release_and_upload:
-    name: Release and Upload
+  build:
+    name: Build wheel and sdist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Run build
+      run: |
+        pipx run build
+
+    - name: Display built files
+      run: |
+        ls -shR
+      working-directory: dist
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist/*
+        name: artifacts
+
+  upload_to_pypi:
+    needs: [build]
+    runs-on: ubuntu-latest
+    name: Upload to pypi
     permissions:
-      # needs write permission to create the GitHub release
-      contents: write
-      # This permission is mandatory for trusted publishing on pypi
+      # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
-    # Use the "reusable workflow" from the hyperspy organisation
-    uses: hyperspy/.github/.github/workflows/release_pure_python.yml@main
-    with:
-      repository_owner: 'hyperspy'
+    steps:
+    - name: Download dist
+      uses: actions/download-artifact@v3
+      with:
+        name: artifacts
+        path: dist
+
+    - name: Display downloaded files
+      run: |
+        ls -shR
+      working-directory: dist
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'hyperspy' }}
+      # See https://docs.pypi.org/trusted-publishers/using-a-publisher/
+
+  create_github_release:
+    # If zenodo is setup to create a DOI automatically on a GitHub release,
+    # this step will trigger the mining of the DOI
+    needs: upload_to_pypi
+    permissions:
+      contents: write
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Create Release
+        if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'hyperspy' }}
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-Changelog
-*********
+Release Notes
+*************
 
 Changelog entries for the development version are available at
 https://holospy.readthedocs.io/en/latest/changes.html

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Release Notes
 Changelog entries for the development version are available at
 https://holospy.readthedocs.io/en/latest/changes.html
 
-0.1.dev0 (UNRELEASED)
-=====================
+0.1 (2023-11-15)
+================
 
 - Add pre-commit configuration file (`#4 <https://github.com/hyperspy/holospy/pull/4>`_)
 - Format code using ``black`` and add workflow to check formatting (`#3 <https://github.com/hyperspy/holospy/pull/3>`_).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,11 @@ Contents
 
    user_guide/index.rst
    api/index.rst
-   changes.rst
-   citing.rst
    contributing.rst
-   license.rst
+   changes.rst
+
+
+.. include:: citing.rst
+
+.. include:: license.rst
+


### PR DESCRIPTION
- Revert to non-reusable workflow as it is not compatible with the use of trusted publisher.
- Trusted publisher set up on pypi.org (https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
- Zenodo set up (https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content)

Publish workflow tested on test.pypi.org:
https://github.com/ericpre/holospy/actions/runs/6868971744
https://test.pypi.org/project/holospy/

