### PR TITLE
Update for pint unit registry in hyperspy

### DIFF
--- a/holospy/tests/signals/test_hologram_image.py
+++ b/holospy/tests/signals/test_hologram_image.py
@@ -24,8 +24,9 @@ import pytest
 from scipy.interpolate import RectBivariateSpline
 
 import hyperspy.api as hs
-from holospy.signals.hologram_image import HologramImage
+from holospy.signals.hologram_image import HologramImage, _ureg
 from hyperspy.decorators import lazifyTestClass
+
 
 # Set parameters outside the tests
 img_size = 256
@@ -330,3 +331,12 @@ def test_reconstruct_phase_multi(lazy):
     #   e. Beam energy is not assigned, while 'mrad' units selected
     with pytest.raises(AttributeError):
         holo_image3.reconstruct_phase(sb_size=40, sb_unit="mrad")
+
+
+def test_pint_unit_registry():
+    # Check that holospy and hyperspy share the same UnitRegistry
+    s = hs.signals.Signal1D(np.arange(10))
+    # this will not work if the UnitRegistry are not the same
+    s.axes_manager[0].scale_as_quantity = "2.5 µm"
+    s.axes_manager[0].scale_as_quantity += 2e-6 * _ureg.meter
+    assert s.axes_manager[0].scale == 4.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = [
   "hyperspy>=2.0rc0",
   "numpy>=1.20.0",
+  "pint>=0.10",
   "scipy>=1.5.0",
 ]
 dynamic = ["version"]

--- a/upcoming_changes/35.maintenance.rst
+++ b/upcoming_changes/35.maintenance.rst
@@ -1,0 +1,1 @@
+Use ``pint.get_application_registry`` instead of HyperSpy private API to get the handle of the ``pint.UnitRegistry``.


### PR DESCRIPTION
See https://github.com/hyperspy/hyperspy/pull/3357 for context

### Progress of the PR
- [x] Use `pint.get_application_registry` instead of HyperSpy private API to get the handle of the `pint.UnitRegistry`,
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/holospy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:holospy` build of this PR (link in github checks)
- [x] ready for review.

