### PR TITLE
Add release notes and distribution files to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,8 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-    - name: Download dist
-      uses: actions/download-artifact@v5
-      with:
-        name: dist
-        path: dist
-
-    - name: Display downloaded files
-      run: |
-        ls -shR
+    - name: Download distribution artefacts
+      uses: hyperspy/.github/.github/actions/download-artifact@main
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'hyperspy' }}
@@ -50,29 +43,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Download dist
-        uses: actions/download-artifact@v5
-        with:
-          name: dist
-          path: dist
-
-      - name: Display downloaded files
-        run: |
-          ls -shR
-
-      - name: Extract release notes
-        id: release_notes
-        uses: hyperspy/.github/.github/actions/extract-release-notes@main
+      - name: Create GitHub Release
+        uses: hyperspy/.github/.github/actions/create-github-release@main
         with:
           changelog: CHANGES.rst
           heading-level: '='
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
-        with:
-          body: ${{ steps.release_notes.outputs.release-notes }}
-          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+
+      - name: Extract release notes
+        id: release_notes
+        uses: hyperspy/.github/.github/actions/extract-release-notes@main
+        with:
+          changelog: CHANGES.rst
+          heading-level: '='
+
       - name: Create Release
-        if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'hyperspy' }}
-        uses: softprops/action-gh-release@aec2ec56f94eb8180ceec724245f64ef008b89f5
+        id: create_release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        with:
+          body: ${{ steps.release_notes.outputs.release-notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Download dist
+        uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: dist
+
+      - name: Display downloaded files
+        run: |
+          ls -shR
+
       - name: Extract release notes
         id: release_notes
         uses: hyperspy/.github/.github/actions/extract-release-notes@main
@@ -65,3 +75,4 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           body: ${{ steps.release_notes.outputs.release-notes }}
+          files: dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "hyperspy>=2.0rc0",
   "numpy>=1.20.0",
   "pint>=0.10",
+  "scikit-image",  # HyperSpy optional dependencies needed for phase unwrapping
   "scipy>=1.5.0",
 ]
 dynamic = ["version"]

--- a/upcoming_changes/66.maintenance.rst
+++ b/upcoming_changes/66.maintenance.rst
@@ -1,0 +1,1 @@
+Update release workflow to upload release notes and artifacts to GitHub releases.


### PR DESCRIPTION
### Progress of the PR
- [x] Add scikit-image as dependencies since it is now a HyperSpy optional dependency,
- [x] Add release notes and distribution files to GitHub release, 
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/hyperspy/holospy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:holospy` build of this PR (link in github checks)
- [x] ready for review.


Example at https://github.com/ericpre/holospy/releases/.